### PR TITLE
Feature/upsert on unique index fields

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "alignObjectProperties": true,
+  "arrayExpand": true,
+  "arrowParens": "always",
+  "jsxBracketSameLine": true,
+  "jsxSingleQuote": true,
+  "printWidth": 100,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/services/utils/content.js
+++ b/services/utils/content.js
@@ -1,9 +1,12 @@
 const importItemByContentType = async (id, item) => {
+  // Get the model definition - Maybe there's a more elegant way?
   const modelName = id.split('.').reverse()[0];
-  const model = strapi.models[modelName];
-  const uniqueIndexes = Object.keys(model.attributes).filter(
-    (aName) => model.attributes[aName].index && model.attributes[aName].unique
+  const { attributes } = strapi.models[modelName];
+  // Get which fields are unique indexes
+  const uniqueIndexes = Object.keys(attributes).filter(
+    (aName) => attributes[aName].index && attributes[aName].unique
   );
+  // Unique fields present in the inserted item will be used to search for existing items
   const search = [];
   uniqueIndexes.forEach((i) => {
     if (item[i]) {

--- a/services/utils/content.js
+++ b/services/utils/content.js
@@ -1,13 +1,36 @@
-const importItemByContentType = (id, item) => {
+const importItemByContentType = async (id, item) => {
+  const modelName = id.split('.').reverse()[0];
+  const model = strapi.models[modelName];
+  const uniqueIndexes = Object.keys(model.attributes).filter(
+    (aName) => model.attributes[aName].index && model.attributes[aName].unique
+  );
+  const search = [];
+  uniqueIndexes.forEach((i) => {
+    if (item[i]) {
+      search.push({
+        [i]: item[i],
+      });
+    }
+  });
+
+  if (search.length > 0) {
+    const existingItem = await strapi.query(id).model.findOne({ $or: search });
+    if (existingItem) {
+      return strapi.query(id).update({ id: existingItem.id }, item);
+    }
+  }
   return strapi.query(id).create(item);
 };
 
 const importSingleType = async (uid, item) => {
   const existing = await strapi.query(uid).find({});
   if (existing.length > 0) {
-    return strapi.query(uid).update({
-      id: existing[0].id,
-    }, item)
+    return strapi.query(uid).update(
+      {
+        id: existing[0].id,
+      },
+      item
+    );
   } else {
     return strapi.query(uid).create(item);
   }
@@ -19,7 +42,7 @@ const findAll = (uid) => {
 
 const deleteByIds = (uid, ids) => {
   return strapi.query(uid).delete({
-    id_in: ids
+    id_in: ids,
   });
 };
 


### PR DESCRIPTION
Hello @lazurey – Let me know if this PR makes sense to you.
I've recently forked your plugin (thanks!) but added the ability to upload existing objects, matching with existing ones, and updating instead of inserting.

In order to do that, I visit the model and search for fields marked as unique index.

At Noken, we use `prettier` to maintain all our code looking the same.
After running prettier, I also added a couple of formatting – Feel free to reject this change if it doesn't make sense, or request changes if this would help.

Best!
FB