### PR TITLE
Added CSV file support [API, ImportForm]

### DIFF
--- a/admin/src/containers/ImportPage/ImportForm.js
+++ b/admin/src/containers/ImportPage/ImportForm.js
@@ -6,6 +6,7 @@ import {FieldRow, FileField, FormAction} from "./ui-components";
 import {readLocalFile} from "../../utils/file";
 import JsonDataDisplay from "../../components/JsonDataDisplay";
 import {importData} from "../../utils/api";
+import { csvParser } from '../../utils/csvParser';
 
 const ImportForm = ({models}) => {
   const options = map(models, convertModelToOption);
@@ -37,7 +38,11 @@ const ImportForm = ({models}) => {
       return;
     }
     setLoading(true);
-    readLocalFile(sourceFile, JSON.parse).then(setSource)
+
+    const filenameSplit = sourceFile.name.split('.');
+    const ext = filenameSplit[filenameSplit.length - 1];
+
+    readLocalFile(sourceFile, ext === 'csv' ? csvParser : JSON.parse).then(setSource)
     .catch((error) => {
       strapi.notification.error(
         "Something wrong when uploading the file, please check the file and try again.");
@@ -77,7 +82,7 @@ const ImportForm = ({models}) => {
       <FileField>
         <input id="source"
                name="source"
-               accept={".json"}
+               accept={".csv,.json"}
                type="file"
                onChange={onSourceFileChange}
         />

--- a/admin/src/utils/csvParser.js
+++ b/admin/src/utils/csvParser.js
@@ -1,0 +1,21 @@
+export const csvParser = (csv) => {
+	const csvLines = csv.split(/\r\n|\n/);
+	const headers = csvLines[0].split(',');
+	const lines = [];
+
+	for (let i = 1; i < csvLines.length; i++) {
+		const data = csvLines[i].split(',');
+
+		if (data.length == headers.length) {
+			const jsonObj = {};
+
+			for (let j = 0; j < headers.length; j++) {
+				jsonObj[headers[j]] = data[j];
+			}
+
+			lines.push(jsonObj);
+		}
+	}
+
+	return lines;
+};

--- a/controllers/ContentExportImport.js
+++ b/controllers/ContentExportImport.js
@@ -3,10 +3,40 @@
 const PLUGIN_ID = 'content-export-import';
 
 const validator = require('./validations');
+const csvHelpers = require("./csvHelpers");
 
 module.exports = {
   importContent: async (ctx) => {
     const importService = strapi.plugins[PLUGIN_ID].services['contentexportimport'];
+
+    let body = ctx.request.body;
+
+    try {
+      // Check if request has files
+      if (ctx.request.files) {
+        // Get files['source']
+        const sourceFile = ctx.request.files["source"].path;
+        const type = ctx.request.files["source"].type;
+
+        // Read and parse file['source']
+        const source = csvHelpers.readFile(
+          sourceFile,
+          type === "text/csv" ? csvHelpers.csvParser : JSON.parse
+        );
+
+        body = {
+          ...body,
+          source,
+        };
+
+        ctx.request.body = body;
+
+        console.log(body);
+      }
+    } catch (err) {
+      console.error("err", err, ctx.request.files);
+    }
+
     const validationResult = validator.validateImportContentRequest(
       ctx.request.body);
     if (validationResult) {

--- a/controllers/csvHelpers.js
+++ b/controllers/csvHelpers.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+
+const readFile = (file, parser) => {
+	try {
+		const content = fs.readFileSync(file).toString('utf-8');
+		console.log('content', content);
+		return parser && typeof parser === 'function' ? parser(content) : content;
+	} catch (err) {
+		throw err;
+	}
+};
+
+const csvParser = (csv) => {
+	const csvLines = csv.split(/\r\n|\n/);
+	const headers = csvLines[0].split(',');
+	const lines = [];
+
+	for (let i = 1; i < csvLines.length; i++) {
+		const data = csvLines[i].split(',');
+
+		if (data.length == headers.length) {
+			const jsonObj = {};
+
+			for (let j = 0; j < headers.length; j++) {
+				jsonObj[headers[j]] = data[j];
+			}
+
+			lines.push(jsonObj);
+		}
+	}
+
+	return lines;
+};
+
+module.exports = {
+	readFile,
+	csvParser
+};


### PR DESCRIPTION
Hi @lazurey,
I was looking for a way to bulk import data into our CMS, and the closest _working_ plugin was yours. Thank you for making it, and saving us some time :)

However, our requirement was to import the data from CSV files, and thus this modification to both the form and the API:
### Form
I have allowed the form to accept both _.csv_ and _.json_ files, and added a small "detour" to the form when a CSV file is imported.
Basically, the imported CSV is first converted to an object, and the normal workflow resumes.
### API
The API now checks for files passed along the form-data, specifically with "source" filed name, and once it finds it, it converts the CSV or JSON data into object, and replaces toe original request's body with the newly created object. This modification is to allow for the resumption of the original workflow.

I have tried to follow your style as much as possible, modify as little formatting as possible, and have not used any dependency, to have as fewer changes as possible, while adding a powerful feature (at least to me :))

Thought others might use this feature, too.

Please do reach out if there are any issues.

Regards,
Zul